### PR TITLE
Fix: Crash when permission is requested by other plugin

### DIFF
--- a/permissions.android.js
+++ b/permissions.android.js
@@ -32,7 +32,7 @@
 
         // We have either gotten a promise from somewhere else or a bug has occurred and android has called us twice
         // In either case we will ignore it...
-        if (typeof promises.granted !== 'function') {
+        if (!promises || typeof promises.granted !== 'function') {
             return;
         }
 


### PR DESCRIPTION
When another plugin(or user code) requests a permission - the `activityRequestPermissionsEvent` event is fired. However, because the permission was not requested by the `nativescript-permissions` plugin there is no track of the request inside the `pendingPromises`. 
This code change prevents the the `Cannot call property "granted" of undefined" in that case`.
