### PR TITLE
Supporting webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nativescript-permissions",
   "version": "1.2.1",
   "description": "A NativeScript plugin to deal with Android permissions",
-  "main": "permissions.js",
+  "main": "permissions",
 	"typings": "index.d.ts",
   "nativescript": {
 	"platforms": {


### PR DESCRIPTION
In order to be a webpack-discoverable module, we need to remove the `.js` suffix in the package.json `main` attribute. This allows webpack to correctly look for `my-module.android.js` or `my-module.ios.js`.

Details here:
http://docs.nativescript.org/angular/tooling/bundling-with-webpack.html#referencing-platform-specific-modules-from-packagejson