### PR TITLE
Update permissions.android.js

### DIFF
--- a/src/permissions.android.js
+++ b/src/permissions.android.js
@@ -175,7 +175,7 @@ function hasSupportVersion4() {
  */
 function hasAndroidX() {
 	//noinspection JSUnresolvedVariable
-	if (!androidx || !androidx.core || !androidx.core.content || !androidx.core.content.ContextCompat || !androidx.core.content.ContextCompat.checkSelfPermission) {
+	if (typeof androidx === "undefined" || !androidx || !androidx.core || !androidx.core.content || !androidx.core.content.ContextCompat || !androidx.core.content.ContextCompat.checkSelfPermission) {
 		return false;
 	}
 	return true;


### PR DESCRIPTION
Checks if androidx is undefined. This fixes the problem I am getting, as you mentioned - you tested both ways - so not sure why I get this issue but you didn't. I guess use this only if others also see the issue? If you would like me to send you details on this demo setup I am trying I can do. Quick info is v2 demo-ng of nativescript plugin: webRTC...
Using Emulator API 27 (Android 8.1) and also Samsung Galaxy Tab S3