### PR TITLE
Added Android 12 bluetooth permissions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -28,4 +28,8 @@ export const PERMISSIONS: {
     READ_CONTACTS: string,
     READ_EXTERNAL_STORAGE: string,
     WRITE_EXTERNAL_STORAGE: string,
+
+    // Android 12
+    BLUETOOTH_SCAN: string,
+    BLUETOOTH_ADVERTISE: string,
 };

--- a/src/permissions.android.js
+++ b/src/permissions.android.js
@@ -34,6 +34,10 @@ const PERMISSIONS = Object.freeze({
 	READ_EXTERNAL_STORAGE: 'android.permission.READ_EXTERNAL_STORAGE',
 	WRITE_EXTERNAL_STORAGE: 'android.permission.WRITE_EXTERNAL_STORAGE',
 
+	// Android 12
+	BLUETOOTH_SCAN: 'android.permission.BLUETOOTH_SCAN',
+	BLUETOOTH_ADVERTISE: 'android.permission.BLUETOOTH_ADVERTISE',
+
 	// Compatibility
 	APP_TRACKING: 'approved',
 });


### PR DESCRIPTION
Added BLUETOOTH_SCAN, BLUETOOTH_ADVERTISE, to the list of permissions, BLUETOOTH_CONNECT already exists under BLUETOOTH.
If an app targets Android 12 (API level 31) or higher, in the manifest file it should declare BLUETOOTH_SCAN when the app scans for Bluetooth devices, and BLUETOOTH_ADVERTISE if the app makes the current device discoverable to other devices. 
The BLUETOOTH_SCAN, BLUETOOTH_ADVERTISE, and BLUETOOTH_CONNECT permissions are runtime permissions

[Android Developer - Bluetooth permissions](https://developer.android.com/guide/topics/connectivity/bluetooth/permissions)